### PR TITLE
Make PooledUtf8String's empty handle 0

### DIFF
--- a/src/Combination.StringPools.Tests/Test_Allocation.cs
+++ b/src/Combination.StringPools.Tests/Test_Allocation.cs
@@ -3,6 +3,16 @@ namespace Combination.StringPools.Tests;
 public class Test_Allocation
 {
     [Fact]
+    public void Default_Is_Empty()
+    {
+        var string1 = PooledUtf8String.Empty;
+
+        PooledUtf8String string2 = default;
+        Assert.Equal(string1, string2);
+        Assert.Equal(0, string2.Length);
+    }
+
+    [Fact]
     public void Freed_On_Dispose()
     {
         var pool = StringPool.Utf8(4096, 1);

--- a/src/Combination.StringPools.Tests/Test_Deduplication.cs
+++ b/src/Combination.StringPools.Tests/Test_Deduplication.cs
@@ -6,11 +6,12 @@ public class Test_Deduplication
 {
     [Theory]
     [InlineData(10000, 10, 100)]
+    [InlineData(10000, 10, 9000)]
     public void Equal_Strings_Deduplicated(int numStrings, int numUniqueStrings, int stringSize)
     {
-        using var pool = StringPool.DeduplicatedUtf8(1024, 1);
+        using var pool = StringPool.DeduplicatedUtf8(stringSize < 1024 ? 1024 : 32768, 1);
         Assert.Equal(0, pool.UsedBytes);
-        Assert.Equal(1024, pool.AllocatedBytes);
+        Assert.Equal(stringSize < 1024 ? 1024 : 32768, pool.AllocatedBytes);
         for (var i = 0; i < numStrings; ++i)
         {
             var someString = new string(Convert.ToChar('ä' + (i % numUniqueStrings)), stringSize);

--- a/src/Combination.StringPools/PooledUtf8String.cs
+++ b/src/Combination.StringPools/PooledUtf8String.cs
@@ -4,14 +4,14 @@ public readonly struct PooledUtf8String : IEquatable<PooledUtf8String>, ICompara
 {
     private readonly ulong handle;
 
-    public static PooledUtf8String Empty => new(ulong.MaxValue);
+    public static PooledUtf8String Empty => default;
 
     internal PooledUtf8String(ulong handle)
     {
-        this.handle = handle;
+        this.handle = unchecked(handle + 1);
     }
 
-    public static implicit operator string(PooledUtf8String s) => Utf8StringPool.Get(s.handle);
+    public static implicit operator string(PooledUtf8String s) => Utf8StringPool.Get(unchecked(s.handle - 1));
 
     public static bool operator ==(PooledUtf8String a, PooledUtf8String b)
     {
@@ -30,12 +30,12 @@ public readonly struct PooledUtf8String : IEquatable<PooledUtf8String>, ICompara
 
     public bool Equals(PooledUtf8String other)
     {
-        return handle == other.handle || Utf8StringPool.StringsEqual(handle, other.handle);
+        return handle == other.handle || Utf8StringPool.StringsEqual(unchecked(handle - 1), unchecked(other.handle - 1));
     }
 
     public int CompareTo(PooledUtf8String other)
     {
-        return Utf8StringPool.StringsCompare(handle, other.handle);
+        return Utf8StringPool.StringsCompare(unchecked(handle - 1), unchecked(other.handle - 1));
     }
 
     public override bool Equals(object? obj)
@@ -44,15 +44,15 @@ public readonly struct PooledUtf8String : IEquatable<PooledUtf8String>, ICompara
     }
 
     public override int GetHashCode()
-        => unchecked((int)StringHash.Compute(Utf8StringPool.GetBytes(handle)));
+        => unchecked((int)StringHash.Compute(Utf8StringPool.GetBytes(unchecked(handle - 1))));
 
-    public override string ToString() => Utf8StringPool.Get(handle);
+    public override string ToString() => Utf8StringPool.Get(unchecked(handle - 1));
 
-    public int Length => Utf8StringPool.GetLength(handle);
+    public int Length => Utf8StringPool.GetLength(unchecked(handle - 1));
 
-    public IUtf8StringPool? StringPool => Utf8StringPool.GetStringPool(handle);
+    public IUtf8StringPool? StringPool => Utf8StringPool.GetStringPool(unchecked(handle - 1));
 
     public long Handle => unchecked((long)(handle ^ 0xaaaaaaaaaaaaaaaaUL));
 
-    public bool IsEmpty => handle == ulong.MaxValue;
+    public bool IsEmpty => handle == 0;
 }


### PR DESCRIPTION
Make PooledUtf8String's empty handle 0 to satisfy PooledUtf8String.Empty == default(PooledUtf8String)

This is an important property when used with serializers