### PR TITLE
[GP-2289] Avoid downcasting to Int32

### DIFF
--- a/src/Combination.StringPools/Utf8StringPool.cs
+++ b/src/Combination.StringPools/Utf8StringPool.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -153,7 +153,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             else
             {
                 ++currentPageIndex;
-                writePosition = (currentPageIndex * pageSize) + structLength;
+                writePosition = (currentPageIndex * (long)pageSize) + structLength;
                 didAlloc = EnsureCapacity(currentPageIndex + 1);
                 writePtr = pages[currentPageIndex];
                 pageStartOffset = 0;


### PR DESCRIPTION
Description:
`writePosition` is of type `long`, but at some point overflows and ends up being a negative number, due to downcasting to `int`. As a result, `pages` is indexed using a negative index (which might be the cause of SIGSEGV (signal segmentation violation) errors).

Jira: GP-2289