### PR TITLE
Use variable-size integer for size prefix

### DIFF
--- a/Performance/Program.cs
+++ b/Performance/Program.cs
@@ -4,8 +4,8 @@ using BenchmarkDotNet.Running;
 using Combination.StringPools;
 using Performance;
 
-var summary = BenchmarkRunner.Run<Deduplication>();
-//var summary = BenchmarkRunner.Run<Hashing>();
+//var summary = BenchmarkRunner.Run<Deduplication>();
+var summary = BenchmarkRunner.Run<Hashing>();
 
 #if false
 foreach (var sizeMultiple in Enumerable.Range(1, 11))

--- a/Performance/Program.cs
+++ b/Performance/Program.cs
@@ -4,8 +4,8 @@ using BenchmarkDotNet.Running;
 using Combination.StringPools;
 using Performance;
 
-//var summary = BenchmarkRunner.Run<Deduplication>();
-var summary = BenchmarkRunner.Run<Hashing>();
+var summary = BenchmarkRunner.Run<Deduplication>();
+//var summary = BenchmarkRunner.Run<Hashing>();
 
 #if false
 foreach (var sizeMultiple in Enumerable.Range(1, 11))

--- a/src/Combination.StringPools.Tests/TestSupport.cs
+++ b/src/Combination.StringPools.Tests/TestSupport.cs
@@ -1,0 +1,17 @@
+using System.Numerics;
+
+public static class TestSupport
+{
+    public static int GetAllocationSize(int length) => length + 1 + (BitOperations.Log2((uint)length) / 7);
+    public static int GetMaxStringSizeForAllocation(int allocationSize)
+    {
+        for (var i = allocationSize - 1; i >= 0; --i)
+        {
+            if (GetAllocationSize(i) == allocationSize)
+            {
+                return i;
+            }
+        }
+        throw new ArgumentOutOfRangeException("allocationSize");
+    }
+}

--- a/src/Combination.StringPools.Tests/Test_Allocation.cs
+++ b/src/Combination.StringPools.Tests/Test_Allocation.cs
@@ -300,7 +300,7 @@ public class Test_Allocation
         var sum = 0L;
         for (var i = 0; i < 1000; ++i)
         {
-            var len = 2 + ("foobar " + i).Length;
+            var len = TestSupport.GetAllocationSize(("foobar " + i).Length);
             sum += len;
         }
 

--- a/src/Combination.StringPools.Tests/Test_Allocation.cs
+++ b/src/Combination.StringPools.Tests/Test_Allocation.cs
@@ -269,7 +269,7 @@ public class Test_Allocation
                         for (var i = 0; !stopped; ++i)
                         {
                             var str = pool.Add("foobar " + (i % 1000));
-                            Interlocked.Add(ref stringSum, 2 + str.ToString().Length);
+                            Interlocked.Add(ref stringSum, TestSupport.GetAllocationSize(str.ToString().Length));
                             if (i == 10000)
                             {
                                 Interlocked.Increment(ref numStarted);

--- a/src/Combination.StringPools.Tests/Test_Deduplication.cs
+++ b/src/Combination.StringPools.Tests/Test_Deduplication.cs
@@ -18,7 +18,7 @@ public class Test_Deduplication
             pool.Add(someString);
         }
 
-        Assert.Equal(((stringSize * 2) + 2) * numUniqueStrings, pool.UsedBytes);
+        Assert.Equal(TestSupport.GetAllocationSize(stringSize * 2) * numUniqueStrings, pool.UsedBytes);
         for (var i = 0; i < numUniqueStrings * 2; ++i)
         {
             var someString = new string(Convert.ToChar('ä' + i), stringSize);
@@ -46,7 +46,7 @@ public class Test_Deduplication
             pool.Add(bytes);
         }
 
-        Assert.Equal(((stringSize * 2) + 2) * numUniqueStrings, pool.UsedBytes);
+        Assert.Equal(TestSupport.GetAllocationSize(stringSize * 2) * numUniqueStrings, pool.UsedBytes);
         for (var i = 0; i < numUniqueStrings * 2; ++i)
         {
             var someString = new string(Convert.ToChar('ä' + i), stringSize);
@@ -102,6 +102,6 @@ public class Test_Deduplication
             t.Join();
         }
 
-        Assert.Equal(10 * (2 + stringSize), pool.UsedBytes);
+        Assert.Equal(10 * TestSupport.GetAllocationSize(stringSize), pool.UsedBytes);
     }
 }

--- a/src/Combination.StringPools.Tests/Test_Multiple.cs
+++ b/src/Combination.StringPools.Tests/Test_Multiple.cs
@@ -69,7 +69,7 @@ public class Test_Multiple
 
         foreach (var pool in pools)
         {
-            Assert.Equal((stringSize + 2) * stringsPerPool, pool.UsedBytes);
+            Assert.Equal(TestSupport.GetAllocationSize(stringSize) * stringsPerPool, pool.UsedBytes);
             pool.Dispose();
             Assert.Equal(0, pool.UsedBytes);
         }
@@ -94,7 +94,7 @@ public class Test_Multiple
                         Assert.Same(pool, str.StringPool);
                     }
 
-                    Assert.Equal(stringsPerPool * (2 + stringSize), pool.UsedBytes);
+                    Assert.Equal(stringsPerPool * TestSupport.GetAllocationSize(stringSize), pool.UsedBytes);
                 });
             t.Start();
             threads.Add(t);
@@ -125,7 +125,7 @@ public class Test_Multiple
                         Assert.Same(pool, str.StringPool);
                     }
 
-                    Assert.Equal(10 * (2 + stringSize), pool.UsedBytes);
+                    Assert.Equal(10 * TestSupport.GetAllocationSize(stringSize), pool.UsedBytes);
                 });
             t.Start();
             threads.Add(t);

--- a/src/Combination.StringPools/Utf8StringPool.cs
+++ b/src/Combination.StringPools/Utf8StringPool.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -90,6 +91,9 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
     PooledUtf8String IUtf8StringPool.Add(ReadOnlySpan<byte> value)
         => AddInternal(value);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static int GetAllocationSize(int length) => length + 1 + (BitOperations.Log2((uint)length) / 7);
+
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     private PooledUtf8String AddInternal(ReadOnlySpan<byte> value)
@@ -100,8 +104,8 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             return PooledUtf8String.Empty;
         }
 
-        var structLength = length + 2;
-        if (structLength > 0xffff || structLength > pageSize)
+        var structLength = GetAllocationSize(length);
+        if (structLength > pageSize)
         {
             throw new ArgumentOutOfRangeException(nameof(value), "String is too long to be pooled");
         }
@@ -163,8 +167,24 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             Interlocked.Add(ref usedBytes, structLength);
             unsafe
             {
-                *(ushort*)(writePtr + pageStartOffset) = checked((ushort)length);
-                var stringWritePtr = new Span<byte>((byte*)(writePtr + pageStartOffset + 2), length);
+                var ptr = (byte*)(writePtr + pageStartOffset);
+                var write = length;
+                while (true)
+                {
+                    if (write > 0x7f)
+                    {
+                        *ptr++ = unchecked((byte)(0x80 | (write & 0x7f)));
+                    }
+                    else
+                    {
+                        *ptr++ = unchecked((byte)write);
+                        break;
+                    }
+
+                    write >>= 7;
+                }
+
+                var stringWritePtr = new Span<byte>(ptr, length);
                 value.CopyTo(stringWritePtr);
             }
 
@@ -347,8 +367,21 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
 
         unsafe
         {
-            var length = ((ushort*)(pages[page] + pageOffset))[0];
-            return new ReadOnlySpan<byte>((byte*)(pages[page] + pageOffset + 2), length);
+            var ptr = (byte*)(pages[page] + pageOffset);
+            var length = 0;
+            var shl = 0;
+            while (true)
+            {
+                var t = *ptr++;
+                length += (t & 0x7f) << shl;
+                shl += 7;
+                if ((t & 0x80) == 0)
+                {
+                    break;
+                }
+            }
+
+            return new ReadOnlySpan<byte>(ptr, length);
         }
     }
 
@@ -397,7 +430,24 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
                 throw new ArgumentOutOfRangeException(nameof(offset), $"Invalid handle value, page {page} is out of range 0..{pages.Count}");
             }
 
-            return unchecked((ushort)Marshal.ReadInt16(pages[page] + pageOffset));
+            unsafe
+            {
+                var ptr = (byte*)(pages[page] + pageOffset);
+                var length = 0;
+                var shl = 0;
+                while (true)
+                {
+                    var t = *ptr++;
+                    length += (t & 0x7f) << shl;
+                    shl += 7;
+                    if ((t & 0x80) == 0)
+                    {
+                        break;
+                    }
+                }
+
+                return length;
+            }
         }
     }
 


### PR DESCRIPTION
Allows strings larger than 65k to be added (assuming the page size is larger) and optimizes storage space for many small strings (<128 bytes).

Broken out from PR #9


Performance impact

Before
| Method | DataSet         | Pool                 | Mean        | Error     | StdDev     | Median      |
|------- |---------------- |--------------------- |------------:|----------:|-----------:|------------:|
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 4,639.18 ns | 92.503 ns | 266.894 ns | 4,563.86 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   401.31 ns |  8.005 ns |   7.862 ns |   399.50 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |   115.02 ns |  0.352 ns |   0.312 ns |   114.98 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 1,533.70 ns | 18.462 ns |  16.366 ns | 1,536.82 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   209.45 ns |  5.817 ns |  16.782 ns |   205.75 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |    90.47 ns |  1.696 ns |   1.503 ns |    90.31 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] |   645.70 ns | 12.502 ns |  14.882 ns |   643.25 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   139.66 ns |  2.829 ns |   7.403 ns |   137.83 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |    61.68 ns |  0.890 ns |   0.789 ns |    61.68 ns |

After
| Method | DataSet         | Pool                 | Mean        | Error     | StdDev     | Median      |
|------- |---------------- |--------------------- |------------:|----------:|-----------:|------------:|
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 4,484.04 ns | 88.240 ns | 174.176 ns | 4,466.85 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   436.64 ns |  8.435 ns |  20.848 ns |   429.44 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |   120.66 ns |  2.289 ns |   2.141 ns |   120.65 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 1,601.54 ns | 31.836 ns |  66.454 ns | 1,593.21 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   212.90 ns |  4.962 ns |  14.077 ns |   208.44 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |    90.45 ns |  0.726 ns |   0.644 ns |    90.24 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] |   643.70 ns | 15.213 ns |  43.649 ns |   628.79 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   142.94 ns |  7.234 ns |  20.870 ns |   138.05 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |    65.49 ns |  1.343 ns |   2.169 ns |    65.36 ns |