### PR TITLE
Improved performance by using a circular dynamically sized dup table

### DIFF
--- a/Performance/Program.cs
+++ b/Performance/Program.cs
@@ -4,8 +4,8 @@ using BenchmarkDotNet.Running;
 using Combination.StringPools;
 using Performance;
 
-//var summary = BenchmarkRunner.Run<Deduplication>();
-var summary = BenchmarkRunner.Run<Hashing>();
+var summary = BenchmarkRunner.Run<Deduplication>();
+//var summary = BenchmarkRunner.Run<Hashing>();
 
 #if false
 foreach (var sizeMultiple in Enumerable.Range(1, 11))

--- a/src/Combination.StringPools/Utf8StringPool.cs
+++ b/src/Combination.StringPools/Utf8StringPool.cs
@@ -15,13 +15,15 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
     private static readonly List<Utf8StringPool?> Pools = new();
     internal static long totalAllocatedBytes, totalUsedBytes, totalAddedBytes;
 
+    internal int overfillCount;
+
     private readonly List<nint> pages = new();
     private readonly int index;
     private long writePosition, usedBytes, addedBytes;
 
-    private readonly List<ulong>?[]? deduplicationTable;
+    private ulong[]? deduplicationTable;
     private readonly DisposeLock disposeLock = new();
-    private readonly int deduplicationTableBits; // Number of bits to use for deduplication table (2^bits entries)
+    private int deduplicationTableBits; // Number of bits to use for deduplication table (2^bits entries)
     private readonly int pageSize;
 
     private readonly object writeLock = new();
@@ -49,7 +51,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
         this.pageSize = pageSize;
         if (deduplicateStrings)
         {
-            deduplicationTable = new List<ulong>?[1 << deduplicationTableBits];
+            deduplicationTable = new ulong[(1 << deduplicationTableBits)];
         }
 
         bool didAlloc;
@@ -172,7 +174,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
 
             if (deduplicationTable is not null)
             {
-                AddToDeduplicationTable(stringHash, handle);
+                AddToDeduplicationTable(deduplicationTable, deduplicationTableBits, stringHash, handle);
             }
 
             if (didAlloc)
@@ -242,45 +244,83 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
                 return false;
             }
 
-            var tableIndex = stringHash & ((1 << deduplicationTableBits) - 1);
-            var table = deduplicationTable[tableIndex];
-            if (table is null)
+            var tableSize = 1 << deduplicationTableBits;
+            var tableIndex = stringHash & (tableSize - 1);
+            for (var i = 0; i < tableSize; i++)
             {
-                offset = ulong.MaxValue;
-                return false;
-            }
-
-            var ct = table.Count;
-            for (var i = 0; i < ct; ++i)
-            {
-                var handle = table[i];
-                var poolOffset = handle & ((1UL << (64 - PoolIndexBits)) - 1);
-                var poolBytes = GetStringBytes(poolOffset);
-                if (poolBytes.Length != value.Length || !value.SequenceEqual(poolBytes))
+                var tableEntry = deduplicationTable[(tableIndex + i) % tableSize];
+                if (tableEntry == 0)
                 {
-                    continue;
+                    offset = ulong.MaxValue;
+                    return false;
                 }
 
-                offset = handle;
-                return true;
-            }
+                var handle = tableEntry - 1;
 
+                var poolOffset = handle & ((1UL << (64 - PoolIndexBits)) - 1);
+                var poolBytes = GetStringBytes(poolOffset);
+                if (poolBytes.Length == value.Length && value.SequenceEqual(poolBytes))
+                {
+                    offset = handle;
+                    return true;
+                }
+            }
             offset = ulong.MaxValue;
             return false;
         }
     }
 
-    private void AddToDeduplicationTable(int stringHash, ulong handle)
+    private void AddToDeduplicationTable(ulong[]? currentTable, int currentTableBits, int stringHash, ulong handle)
     {
-        if (deduplicationTable == null)
+        if (currentTable == null)
         {
             return;
         }
 
-        var tableIndex = stringHash & ((1 << deduplicationTableBits) - 1);
-        var table = deduplicationTable[tableIndex] ?? (deduplicationTable[tableIndex] = new List<ulong>());
+        var tableSize = 1 << currentTableBits;
+        var tableIndex = stringHash & (tableSize - 1);
+        for (var i = 0; i < tableSize; i++)
+        {
+            var tableEntry = currentTable[(tableIndex + i) % tableSize];
+            if (tableEntry == 0)
+            {
+                if (i > 0)
+                {
+                    ++overfillCount;
+                }
+                currentTable[(tableIndex + i) % tableSize] = handle + 1;
+                if (overfillCount > tableSize / 2)
+                {
+                    ResizeDeduplicationTable(currentTableBits + 1);
+                }
+                return;
+            }
+        }
+        ResizeDeduplicationTable(currentTableBits + 1);
+    }
 
-        table.Add(handle);
+    private void ResizeDeduplicationTable(int newBits)
+    {
+        if (deduplicationTable is null)
+        {
+            return;
+        }
+        var newDeduplicationTable = new ulong[1 << newBits];
+        overfillCount = 0;
+        var tableSize = 1 << deduplicationTableBits;
+        for (var i = 0; i < tableSize; ++i)
+        {
+            var tableEntry = deduplicationTable[i];
+            if (tableEntry != 0)
+            {
+                var handle = tableEntry - 1;
+                var poolOffset = handle & ((1UL << (64 - PoolIndexBits)) - 1);
+                var poolBytes = GetStringBytes(poolOffset);
+                AddToDeduplicationTable(newDeduplicationTable, newBits, (int)StringHash.Compute(poolBytes), handle);
+            }
+        }
+        deduplicationTable = newDeduplicationTable;
+        deduplicationTableBits = newBits;
     }
 
     public static string Get(ulong handle)


### PR DESCRIPTION
Inspired by #9 but less intrusive changes. Since it scales more aggressively there is a chance it uses more memory, but at the same time it should have less overhead per dup entry on average owing to its flat format.

The main benefit of this is that the performance becomes more predictable with less tuning required. It also allocates fewer objects so should reduce GC pressure significantly.

## Before change
| Method | DataSet         | Pool                 | Mean        | Error     | StdDev     | Median      |
|------- |---------------- |--------------------- |------------:|----------:|-----------:|------------:|
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 4,639.18 ns | 92.503 ns | 266.894 ns | 4,563.86 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   401.31 ns |  8.005 ns |   7.862 ns |   399.50 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |   115.02 ns |  0.352 ns |   0.312 ns |   114.98 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 1,533.70 ns | 18.462 ns |  16.366 ns | 1,536.82 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   209.45 ns |  5.817 ns |  16.782 ns |   205.75 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |    90.47 ns |  1.696 ns |   1.503 ns |    90.31 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] |   645.70 ns | 12.502 ns |  14.882 ns |   643.25 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |   139.66 ns |  2.829 ns |   7.403 ns |   137.83 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |    61.68 ns |  0.890 ns |   0.789 ns |    61.68 ns |

## After change
| Method | DataSet         | Pool                 | Mean      | Error    | StdDev    |
|------- |---------------- |--------------------- |----------:|---------:|----------:|
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 437.56 ns | 8.702 ns | 15.912 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] | 105.96 ns | 2.142 ns |  3.917 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |  74.33 ns | 0.998 ns |  0.833 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 410.85 ns | 7.743 ns |  7.243 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] |  99.77 ns | 2.003 ns |  1.776 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |  74.41 ns | 1.467 ns |  1.225 ns |
| DoAdd  | String[1000000] | Utf8S(...)ed=0) [61] | 431.01 ns | 8.385 ns | 10.298 ns |
| DoAdd  | String[100000]  | Utf8S(...)ed=0) [61] | 111.95 ns | 4.492 ns | 12.743 ns |
| DoAdd  | String[10000]   | Utf8S(...)ed=0) [61] |  59.24 ns | 0.826 ns |  0.773 ns |