### PR TITLE
[Breaking change] Remove deduplicationTableBits parameter

### DIFF
--- a/Performance/Deduplication.cs
+++ b/Performance/Deduplication.cs
@@ -28,7 +28,7 @@ public class Deduplication
     }
 
     public IEnumerable<IUtf8DeduplicatedStringPool> CreatePools()
-        => (new[] { 10, 12, 16 }).Select(bits => StringPool.DeduplicatedUtf8(4096, 1, bits));
+        => [StringPool.DeduplicatedUtf8(4096, 1)];
 
     internal static string RandomString()
     {

--- a/Performance/Hashing.cs
+++ b/Performance/Hashing.cs
@@ -7,7 +7,7 @@ namespace Performance;
 #pragma warning disable IDE1006 // Naming Styles
 public class Hashing
 {
-    private static readonly IUtf8DeduplicatedStringPool pool = StringPool.DeduplicatedUtf8(4096, 1, 12);
+    private static readonly IUtf8DeduplicatedStringPool pool = StringPool.DeduplicatedUtf8(4096, 1);
 
     [ParamsSource(nameof(CreateStrings))]
     public PooledUtf8String String;

--- a/src/Combination.StringPools/StringPool.cs
+++ b/src/Combination.StringPools/StringPool.cs
@@ -21,17 +21,7 @@ public static class StringPool
     /// <param name="pageSize">The size of the memory pages to allocate (allocation increment quantum).</param>
     /// <param name="initialPageCount">The initial number of pages to allocate.</param>
     /// <returns>The newly create string pool.</returns>
-    public static IUtf8StringPool Utf8(int pageSize, int initialPageCount) => Utf8(pageSize, initialPageCount, DefaultDeduplicationTableBits);
-
-    /// <summary>
-    /// A Utf8 string pool that does not deduplicate strings, created with specified page size and initial page count.
-    /// </summary>
-    /// <param name="pageSize">The size of the memory pages to allocate (allocation increment quantum).</param>
-    /// <param name="initialPageCount">The initial number of pages to allocate.</param>
-    /// <param name="deduplicationTableBits">Number of bits in the deduplication table (size will be 2^bits).</param>
-    /// <returns>The newly create string pool.</returns>
-    public static IUtf8StringPool Utf8(int pageSize, int initialPageCount, int deduplicationTableBits) =>
-        new Utf8StringPool(pageSize, initialPageCount, false, deduplicationTableBits);
+    public static IUtf8StringPool Utf8(int pageSize, int initialPageCount) => new Utf8StringPool(pageSize, initialPageCount, false, DefaultDeduplicationTableBits);
 
 
     /// <summary>
@@ -47,17 +37,7 @@ public static class StringPool
     /// <param name="initialPageCount">The initial number of pages to allocate.</param>
     /// <returns>The newly create string pool.</returns>
     public static IUtf8DeduplicatedStringPool DeduplicatedUtf8(int pageSize, int initialPageCount) =>
-        DeduplicatedUtf8(pageSize, initialPageCount, DefaultDeduplicationTableBits);
-
-    /// <summary>
-    /// A Utf8 string pool that de-duplicates equal strings, created with specified page size and initial page count.
-    /// </summary>
-    /// <param name="pageSize">The size of the memory pages to allocate (allocation increment quantum).</param>
-    /// <param name="initialPageCount">The initial number of pages to allocate.</param>
-    /// <param name="deduplicationTableBits">Number of bits in the deduplication table (size will be 2^bits).</param>
-    /// <returns>The newly create string pool.</returns>
-    public static IUtf8DeduplicatedStringPool DeduplicatedUtf8(int pageSize, int initialPageCount, int deduplicationTableBits) =>
-        new Utf8StringPool(pageSize, initialPageCount, true, deduplicationTableBits);
+        new Utf8StringPool(pageSize, initialPageCount, true, DefaultDeduplicationTableBits);
 
     /// <summary>
     /// The total number of bytes allocated in all string pools.


### PR DESCRIPTION
Depends on #32. If this is merged, the major version needs to be bumped since this is a breaking change to public API.

The idea is that there is no need to tune the bits of the dedup table now that it auto scales