### PR TITLE
Improve performance of deduplication

### DIFF
--- a/Performance/Filter.cs
+++ b/Performance/Filter.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+using Combination.StringPools;
+
+namespace Performance;
+
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable CS8618
+public class Filter
+{
+    internal static readonly Random Random = new();
+
+    [Params(10_000, 32_525, 100_000, 1_000_000)]
+    public int PoolSize;
+
+    private IUtf8DeduplicatedStringPool filledPool;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        filledPool = StringPool.DeduplicatedUtf8(4096, 1);
+        for (var i = 0; i < PoolSize; i++)
+        {
+            filledPool.Add(Guid.NewGuid().ToString());
+        }
+    }
+
+    [Benchmark]
+    public PooledUtf8String? DoTryGet()
+    {
+        return filledPool.TryGet("not-in-pool");
+    }
+}

--- a/Performance/Program.cs
+++ b/Performance/Program.cs
@@ -2,6 +2,7 @@
 using Performance;
 
 var summary = BenchmarkRunner.Run<Deduplication>();
+// var summary = BenchmarkRunner.Run<Filter>();
 //var summary = BenchmarkRunner.Run<Hashing>();
 
 #if false

--- a/src/Combination.StringPools/Utf8StringPool.cs
+++ b/src/Combination.StringPools/Utf8StringPool.cs
@@ -21,7 +21,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
     internal static long totalAddedBytes;
 #pragma warning restore IDE1006 // Naming Styles
 
-    internal int overfillCount;
+    internal int deduplicationFillCount;
 
     private readonly List<nint> pages = new();
     private readonly int index;
@@ -309,12 +309,9 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             var tableEntry = currentTable[(tableIndex + i) % tableSize];
             if (tableEntry == 0)
             {
-                if (i > 0)
-                {
-                    ++overfillCount;
-                }
+                ++deduplicationFillCount;
                 currentTable[(tableIndex + i) % tableSize] = handle + 1;
-                if (overfillCount > tableSize / 2)
+                if (deduplicationFillCount > tableSize * 0.8)
                 {
                     ResizeDeduplicationTable(currentTableBits + 1);
                 }
@@ -331,7 +328,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             return;
         }
         var newDeduplicationTable = new ulong[1 << newBits];
-        overfillCount = 0;
+        deduplicationFillCount = 0;
         var tableSize = 1 << deduplicationTableBits;
         for (var i = 0; i < tableSize; ++i)
         {

--- a/src/Combination.StringPools/Utf8StringPool.cs
+++ b/src/Combination.StringPools/Utf8StringPool.cs
@@ -13,6 +13,9 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
         PoolIndexBits =
             24; // Number of bits to use for pool index in handle (more bits = more pools, but less strings per pool)
 
+    // Maximum fill factor for deduplication table. Performance degrades when it is close to 1.
+    private const float MaxDeduplicationTableFillFactor = 0.8f;
+
     private static readonly List<Utf8StringPool?> Pools = new();
 
 #pragma warning disable IDE1006 // Naming Styles
@@ -311,7 +314,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             {
                 ++deduplicationFillCount;
                 currentTable[(tableIndex + i) % tableSize] = handle + 1;
-                if (deduplicationFillCount > tableSize * 0.8)
+                if (deduplicationFillCount > tableSize * MaxDeduplicationTableFillFactor)
                 {
                     ResizeDeduplicationTable(currentTableBits + 1);
                 }

--- a/src/Combination.StringPools/Utf8StringPool.cs
+++ b/src/Combination.StringPools/Utf8StringPool.cs
@@ -14,7 +14,7 @@ internal sealed class Utf8StringPool : IUtf8DeduplicatedStringPool
             24; // Number of bits to use for pool index in handle (more bits = more pools, but less strings per pool)
 
     // Maximum fill factor for deduplication table. Performance degrades when it is close to 1.
-    private const float MaxDeduplicationTableFillFactor = 0.8f;
+    private const float MaxDeduplicationTableFillFactor = 0.9f;
 
     private static readonly List<Utf8StringPool?> Pools = new();
 


### PR DESCRIPTION
The old code grows deduplication table when it is almost full. This causes a big degradation in performance for looking up non existing strings when the table is almost full because we always get hash a collision and have to iterate almost the whole table. Some tuning can be done for MaxDeduplicationTableFillFactor but 0.9 seems an ok value, not much perf improvement going lower.


Small improvements in the Addition benchmark and big improvement in the new Filter benchmark:

old:
| Method   | PoolSize | Mean        | Error     | StdDev    |
|--------- |--------- |------------:|----------:|----------:|
| DoTryGet | 10000    |    13.48 ns |  0.064 ns |  0.057 ns |
| DoTryGet | 32525    | 9,420.57 ns | 91.941 ns | 76.775 ns |
| DoTryGet | 100000   |    20.26 ns |  0.351 ns |  0.329 ns |
| DoTryGet | 1000000  |   587.54 ns |  8.753 ns |  8.188 ns |

new:
| Method   | PoolSize | Mean     | Error    | StdDev   |
|--------- |--------- |---------:|---------:|---------:|
| DoTryGet | 10000    | 10.95 ns | 0.175 ns | 0.163 ns |
| DoTryGet | 32525    | 14.86 ns | 0.105 ns | 0.099 ns |
| DoTryGet | 100000   | 13.51 ns | 0.149 ns | 0.140 ns |
| DoTryGet | 1000000  | 10.87 ns | 0.124 ns | 0.110 ns |

Size 32525 is a degenerate case where the old table is almost full